### PR TITLE
Add register_without_lookup method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # avro_schema_registry-client
 
 ## v0.2.0
-- Add `register_and_lookup` and `register_without_lookup` methods to
-  `AvroSchemaRegistry::Client`.
+- Add `register_without_lookup` methods to `AvroSchemaRegistry::Client`.
 
 ## v0.1.0
 - Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # avro_schema_registry-client
 
 ## v0.2.0
-- Add `register_without_lookup` methods to `AvroSchemaRegistry::Client`.
+- Add `register_without_lookup` method to `AvroSchemaRegistry::Client`.
 
 ## v0.1.0
 - Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # avro_schema_registry-client
 
+## v0.2.0
+- Add `register_and_lookup` and `register_without_lookup` methods to
+  `AvroSchemaRegistry::Client`.
+
 ## v0.1.0
 - Initial version

--- a/lib/avro_schema_registry/client.rb
+++ b/lib/avro_schema_registry/client.rb
@@ -34,11 +34,6 @@ module AvroSchemaRegistry
       id
     end
 
-    def register_and_lookup(subject, schema, **params)
-      register_without_lookup(subject, schema, params)
-      lookup_subject_schema(subject, schema)
-    end
-
     # Override to add support for additional params
     def compatible?(subject, schema, version = 'latest', **params)
       data = post("/compatibility/subjects/#{subject}/versions/#{version}",

--- a/lib/avro_schema_registry/client.rb
+++ b/lib/avro_schema_registry/client.rb
@@ -21,15 +21,22 @@ module AvroSchemaRegistry
     # Override register to first check if a schema is registered by fingerprint
     # Also, allow additional params to be passed to register.
     def register(subject, schema, **params)
-
       lookup_subject_schema(subject, schema)
     rescue Excon::Errors::NotFound
+      register_without_lookup(subject, schema, params)
+    end
+
+    def register_without_lookup(subject, schema, **params)
       data = post("/subjects/#{subject}/versions",
                   body: { schema: schema.to_s }.merge!(params).to_json)
       id = data.fetch('id')
       @logger.info("Registered schema for subject `#{subject}`; id = #{id}")
       id
+    end
 
+    def register_and_lookup(subject, schema, **params)
+      register_without_lookup(subject, schema, params)
+      lookup_subject_schema(subject, schema)
     end
 
     # Override to add support for additional params

--- a/lib/avro_schema_registry/version.rb
+++ b/lib/avro_schema_registry/version.rb
@@ -1,3 +1,3 @@
 module AvroSchemaRegistry
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/avro_schema_registry/client_spec.rb
+++ b/spec/avro_schema_registry/client_spec.rb
@@ -83,30 +83,6 @@ describe AvroSchemaRegistry::Client do
     end
   end
 
-  describe "#register_and_lookup" do
-    it "allows registration of an Avro JSON schema" do
-      id = registry.register_and_lookup(subject_name, schema)
-      expect(registry.fetch(id)).to eq(avro_schema.to_s)
-    end
-
-    it "allows the registration of an Avro::Schema" do
-      id = registry.register_and_lookup(subject_name, avro_schema)
-      expect(registry.fetch(id)).to eq(avro_schema.to_s)
-    end
-
-    it "makes a request to check if the schema exists after attempting to register" do
-      allow(registry).to receive(:get).and_call_original
-      registry.register_and_lookup(subject_name, avro_schema)
-      expect(registry).to have_received(:get)
-    end
-
-    it "allows compatibility parameters to be specified" do
-      id = registry.register_and_lookup(subject_name, avro_schema,
-                                        with_compatibility: 'NONE', after_compatibility: 'FULL')
-      expect(registry.fetch(id)).to eq(avro_schema.to_s)
-    end
-  end
-
   describe "#lookup_subject_schema" do
     context "when the schema does not exist" do
       it "raises an error" do

--- a/spec/avro_schema_registry/client_spec.rb
+++ b/spec/avro_schema_registry/client_spec.rb
@@ -58,6 +58,55 @@ describe AvroSchemaRegistry::Client do
     end
   end
 
+  describe "#register_without_lookup" do
+    it "allows registration of an Avro JSON schema" do
+      id = registry.register_without_lookup(subject_name, schema)
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
+    end
+
+    it "allows the registration of an Avro::Schema" do
+      id = registry.register_without_lookup(subject_name, avro_schema)
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
+    end
+
+    it "does not makes a request to lookup the schema before attempting to register" do
+      id = registry.register_without_lookup(subject_name, avro_schema)
+      allow(registry).to receive(:post).and_return('id' => id)
+      expect(registry.register_without_lookup(subject_name, avro_schema)).to eq(id)
+      expect(registry).to have_received(:post)
+    end
+
+    it "allows compatibility parameters to be specified" do
+      id = registry.register_without_lookup(subject_name, avro_schema,
+                                            with_compatibility: 'NONE', after_compatibility: 'FULL')
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
+    end
+  end
+
+  describe "#register_and_lookup" do
+    it "allows registration of an Avro JSON schema" do
+      id = registry.register_and_lookup(subject_name, schema)
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
+    end
+
+    it "allows the registration of an Avro::Schema" do
+      id = registry.register_and_lookup(subject_name, avro_schema)
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
+    end
+
+    it "makes a request to check if the schema exists after attempting to register" do
+      allow(registry).to receive(:get).and_call_original
+      registry.register_and_lookup(subject_name, avro_schema)
+      expect(registry).to have_received(:get)
+    end
+
+    it "allows compatibility parameters to be specified" do
+      id = registry.register_and_lookup(subject_name, avro_schema,
+                                        with_compatibility: 'NONE', after_compatibility: 'FULL')
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
+    end
+  end
+
   describe "#lookup_subject_schema" do
     context "when the schema does not exist" do
       it "raises an error" do


### PR DESCRIPTION
I was adding a `register_without_lookup` method to avoid the cost of an extra request when registering new schema versions in `avrolution`. Then I had the idea that it might also be useful to ensure that schemas are cached by CloudFront immediately after registration, hence `register_and_lookup`.

Prime: @jturkel 