### PR TITLE
Add Ruby 3.2 Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.7.6
+      - image: salsify/ruby_ci:2.7.7
     working_directory: ~/avro_schema_registry-client
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.7.6-{{ checksum "avro_schema_registry-client.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.7.6-
+            - v1-gems-ruby-2.7.7-{{ checksum "avro_schema_registry-client.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.7.7-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.7.6-{{ checksum "avro_schema_registry-client.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-2.7.7-{{ checksum "avro_schema_registry-client.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,6 +66,7 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - "2.7.6"
-                - "3.0.4"
-                - "3.1.2"
+                - "2.7.7"
+                - "3.0.5"
+                - "3.1.3"
+                - "3.2.0"


### PR DESCRIPTION
This adds Ruby 3.2 to the test matrix. No changes were required to get the tests passing.